### PR TITLE
Override of AdapterView.getSelectedItemPosition(). 

### DIFF
--- a/viewflow/src/org/taptwo/android/widget/ViewFlow.java
+++ b/viewflow/src/org/taptwo/android/widget/ViewFlow.java
@@ -495,6 +495,11 @@ public class ViewFlow extends AdapterView<Adapter> {
 				.get(mCurrentBufferIndex) : null);
 	}
 
+    @Override
+    public int getSelectedItemPosition() {
+        return mCurrentAdapterIndex;
+    }
+
 	/**
 	 * Set the FlowIndicator
 	 * 


### PR DESCRIPTION
Override AdapterView.getSelectedItemPosition() in ViewFlow to get correct index of currently selected view from adapter.
