### PR TITLE
'clipPadding' property for TitleFlowIndicator is introduced. 

### DIFF
--- a/viewflow-example/AndroidManifest.xml
+++ b/viewflow-example/AndroidManifest.xml
@@ -13,6 +13,11 @@
 
 		</activity>
 		
+		<activity android:name="TitleViewFlowWithPaddingExample" android:label="@string/app_name"
+            android:configChanges="orientation">
+
+        </activity>
+		
 		<activity android:name="ViewFlowExample" android:label="@string/app_name">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN"></action>

--- a/viewflow-example/default.properties
+++ b/viewflow-example/default.properties
@@ -9,4 +9,4 @@
 
 # Project target.
 target=android-8
-android.library.reference.1=../viewflow/
+android.library.reference.1=../viewflow

--- a/viewflow-example/res/layout/title_with_padding_layout.xml
+++ b/viewflow-example/res/layout/title_with_padding_layout.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res/org.taptwo.android.widget.viewflow.example"
+	android:orientation="vertical" android:layout_width="fill_parent"
+	android:layout_height="fill_parent">
+	<LinearLayout android:layout_width="fill_parent"
+		android:gravity="center_horizontal" android:id="@+id/header_layout"
+		android:orientation="vertical" android:layout_height="wrap_content">
+		<org.taptwo.android.widget.TitleFlowIndicator
+			android:id="@+id/viewflowindic" android:layout_height="wrap_content"
+			android:layout_width="fill_parent" app:footerLineHeight="2"
+			app:footerTriangleHeight="10" app:textColor="#FFFFFFFF"
+			app:selectedColor="#FFFFC445" app:footerColor="#FFFFC445"
+			app:titlePadding="10" app:textSize="13" android:layout_marginTop="10dip"
+			app:clipPadding="5" />
+
+	</LinearLayout>
+	<org.taptwo.android.widget.ViewFlow
+		android:duplicateParentState="true" android:id="@+id/viewflow"
+		android:layout_width="fill_parent" android:layout_height="fill_parent" />
+</LinearLayout> 

--- a/viewflow-example/src/org/taptwo/android/widget/viewflow/example/TitleViewFlowWithPaddingExample.java
+++ b/viewflow-example/src/org/taptwo/android/widget/viewflow/example/TitleViewFlowWithPaddingExample.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2011 Patrik �kerfeldt
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.taptwo.android.widget.viewflow.example;
+
+import org.taptwo.android.widget.TitleFlowIndicator;
+import org.taptwo.android.widget.ViewFlow;
+
+import android.app.Activity;
+import android.content.res.Configuration;
+import android.os.Bundle;
+
+/**
+ * Class is similar to {@link TitleViewFlowExample} but layout contains
+ * additionally clip padding on the left and on the right of not current title.
+ * 
+ */
+public class TitleViewFlowWithPaddingExample extends Activity {
+
+    private ViewFlow viewFlow;
+
+    /** Called when the activity is first created. */
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+	super.onCreate(savedInstanceState);
+	setTitle(R.string.title_title);
+	setContentView(R.layout.title_with_padding_layout);
+
+	viewFlow = (ViewFlow) findViewById(R.id.viewflow);
+	AndroidVersionAdapter adapter = new AndroidVersionAdapter(this);
+	viewFlow.setAdapter(adapter);
+	TitleFlowIndicator indicator = (TitleFlowIndicator) findViewById(R.id.viewflowindic);
+	indicator.setTitleProvider(adapter);
+	viewFlow.setFlowIndicator(indicator);
+
+    }
+
+    /*
+     * If your min SDK version is < 8 you need to trigger the
+     * onConfigurationChanged in ViewFlow manually, like this
+     */
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+	super.onConfigurationChanged(newConfig);
+	viewFlow.onConfigurationChanged(newConfig);
+    }
+
+}

--- a/viewflow-example/src/org/taptwo/android/widget/viewflow/example/ViewFlowExample.java
+++ b/viewflow-example/src/org/taptwo/android/widget/viewflow/example/ViewFlowExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Patrik Åkerfeldt
+ * Copyright (C) 2011 Patrik ÔøΩkerfeldt
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class ViewFlowExample extends Activity {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.main);
 		listView = (ListView) findViewById(R.id.menu);
-		String[] listeStrings = { "Circle indicator...", "Title indicator..." };
+		String[] listeStrings = { "Circle indicator...", "Title indicator...", "Title indicator (clip Padding)..." };
 		listView.setAdapter(new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, listeStrings));
 		listView.setOnItemClickListener(new OnItemClickListener() {
 			@Override
@@ -46,7 +46,10 @@ public class ViewFlowExample extends Activity {
 				case 1:
 					startActivity(new Intent(ViewFlowExample.this, TitleViewFlowExample.class));
 					break;
-				}
+			        case 2:
+				        startActivity(new Intent(ViewFlowExample.this, TitleViewFlowWithPaddingExample.class));
+				        break;
+			        }
 			}
 		});
 	}

--- a/viewflow/res/values/attrs.xml
+++ b/viewflow/res/values/attrs.xml
@@ -26,6 +26,7 @@
     </declare-styleable>    
     <declare-styleable name="TitleFlowIndicator">
         <attr name="titlePadding" format="integer" />
+        <attr name="clipPadding" format="integer" />
         <attr name="selectedColor" format="color" />
         <attr name="selectedBold" format="boolean" />
         <attr name="textColor" format="color" />

--- a/viewflow/src/org/taptwo/android/widget/TitleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/TitleFlowIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Patrik Åkerfeldt
+ * Copyright (C) 2011 Patrik ÔøΩkerfeldt
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import android.widget.TextView;
 public class TitleFlowIndicator extends TextView implements FlowIndicator {
 
 	private static final int TITLE_PADDING = 10;
+	private static final int CLIP_PADDING = 0;
 	private static final int SELECTED_COLOR = 0xFFFFC445;
 	private static final boolean SELECTED_BOLD = false;
 	private static final int TEXT_COLOR = 0xFFAAAAAA;
@@ -57,6 +58,7 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
 	private Paint paintFooterTriangle;
 	private int footerTriangleHeight;
 	private int titlePadding;
+	private int clipPadding;
 	private int footerLineHeight;
 
 	/**
@@ -86,6 +88,7 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
 		int textColor = a.getColor(R.styleable.TitleFlowIndicator_textColor, TEXT_COLOR);
 		float textSize = a.getFloat(R.styleable.TitleFlowIndicator_textSize, TEXT_SIZE);
 		titlePadding = a.getInt(R.styleable.TitleFlowIndicator_titlePadding, TITLE_PADDING);
+		clipPadding = a.getColor(R.styleable.TitleFlowIndicator_clipPadding, CLIP_PADDING);
 		initDraw(textColor, textSize, selectedColor, selectedBold, footerLineHeight, footerColor);
 	}
 
@@ -131,13 +134,11 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
 		int curViewWidth = curViewBound.right - curViewBound.left;
 		if (curViewBound.left < 0) {
 			// Try to clip to the screen (left side)
-			curViewBound.left = 0;
-			curViewBound.right = curViewWidth;
+			clipViewOnTheLeft(curViewBound, curViewWidth);
 		}
 		if (curViewBound.right > getLeft() + getWidth()) {
 			// Try to clip to the screen (right side)
-			curViewBound.right = getLeft() + getWidth();
-			curViewBound.left = curViewBound.right - curViewWidth;
+			clipViewOnTheRight(curViewBound, curViewWidth);
 		}
 		
 		// Left views starting from the current position
@@ -148,8 +149,7 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
 				// Si left side is outside the screen
 				if (bound.left < 0) {
 					// Try to clip to the screen (left side)
-					bound.left = 0;
-					bound.right = w;
+					 clipViewOnTheLeft(bound, w);
 					// Except if there's an intersection with the right view
 					if (iLoop < count - 1 && currentPosition != iLoop) {
 						Rect rightBound = bounds.get(iLoop + 1);
@@ -169,8 +169,7 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
 				// If right side is outside the screen
 				if (bound.right > getLeft() + getWidth()) {
 					// Try to clip to the screen (right side)
-					bound.right = getLeft() + getWidth();
-					bound.left = bound.right - w;
+					clipViewOnTheRight(bound, w);
 					// Except if there's an intersection with the left view
 					if (iLoop > 0 && currentPosition != iLoop) {
 						Rect leftBound = bounds.get(iLoop - 1);
@@ -215,6 +214,16 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
         canvas.drawPath(path, paintFooterTriangle);
 
 	}
+	
+    private void clipViewOnTheRight(Rect curViewBound, int curViewWidth) {
+	curViewBound.right = getLeft() + getWidth() - clipPadding;
+	curViewBound.left = curViewBound.right - curViewWidth;
+    }
+
+    private void clipViewOnTheLeft(Rect curViewBound, int curViewWidth) {
+	curViewBound.left = 0 + clipPadding;
+	curViewBound.right = curViewWidth;
+    }
 
 	/**
 	 * Calculate views bounds and scroll them according to the current index


### PR DESCRIPTION
Integer value that is defined by the property is used on the left side of the left view title and on the right side of the right view title so the views can have padding to the border to the parent view. Default value is 0. 

'clipPadding' can be defined as attribute in xml layout see title_with_padding_layout.xml in viewflow_example project.
