### PR TITLE
'clipPadding' property for TitleFlowIndicator is introduced.

### DIFF
--- a/viewflow-example/res/layout/title_layout.xml
+++ b/viewflow-example/res/layout/title_layout.xml
@@ -10,7 +10,7 @@
 			android:id="@+id/viewflowindic" android:layout_height="wrap_content"
 			android:layout_width="fill_parent"
 			app:footerLineHeight="2"
-			app:footerTriangleHeight="10" app:textColor="#FFFFFFFF" app:selectedColor="#FFFFC445" app:footerColor="#FFFFC445" app:titlePadding="10" app:textSize="13" android:layout_marginTop="10dip"></org.taptwo.android.widget.TitleFlowIndicator>
+			app:footerTriangleHeight="10" app:textColor="#FFFFFFFF" app:selectedColor="#FFFFC445" app:footerColor="#FFFFC445" app:titlePadding="10" app:textSize="13" android:layout_marginTop="10dip" app:clipPadding="5"></org.taptwo.android.widget.TitleFlowIndicator>
 
 	</LinearLayout>
 	<org.taptwo.android.widget.ViewFlow

--- a/viewflow/res/values/attrs.xml
+++ b/viewflow/res/values/attrs.xml
@@ -26,6 +26,8 @@
     </declare-styleable>    
     <declare-styleable name="TitleFlowIndicator">
         <attr name="titlePadding" format="integer" />
+        <!-- Left/right padding of not active view titles. -->
+        <attr name="clipPadding" format="integer" />
         <attr name="selectedColor" format="color" />
         <attr name="selectedBold" format="boolean" />
         <attr name="textColor" format="color" />

--- a/viewflow/src/org/taptwo/android/widget/TitleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/TitleFlowIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Patrik Åkerfeldt
+ * Copyright (C) 2011 Patrik ÔøΩkerfeldt
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import android.widget.TextView;
 public class TitleFlowIndicator extends TextView implements FlowIndicator {
 
 	private static final int TITLE_PADDING = 10;
+	private static final int CLIP_PADDING = 0;
 	private static final int SELECTED_COLOR = 0xFFFFC445;
 	private static final boolean SELECTED_BOLD = false;
 	private static final int TEXT_COLOR = 0xFFAAAAAA;
@@ -57,6 +58,10 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
 	private Paint paintFooterTriangle;
 	private int footerTriangleHeight;
 	private int titlePadding;
+	/**
+	 * Left and right side padding for not active view titles.
+	 */
+	private int clipPadding;
 	private int footerLineHeight;
 
 	/**
@@ -86,6 +91,7 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
 		int textColor = a.getColor(R.styleable.TitleFlowIndicator_textColor, TEXT_COLOR);
 		float textSize = a.getFloat(R.styleable.TitleFlowIndicator_textSize, TEXT_SIZE);
 		titlePadding = a.getInt(R.styleable.TitleFlowIndicator_titlePadding, TITLE_PADDING);
+		clipPadding = a.getColor(R.styleable.TitleFlowIndicator_clipPadding, CLIP_PADDING);
 		initDraw(textColor, textSize, selectedColor, selectedBold, footerLineHeight, footerColor);
 	}
 
@@ -131,13 +137,11 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
 		int curViewWidth = curViewBound.right - curViewBound.left;
 		if (curViewBound.left < 0) {
 			// Try to clip to the screen (left side)
-			curViewBound.left = 0;
-			curViewBound.right = curViewWidth;
+			clipViewOnTheLeft(curViewBound, curViewWidth);
 		}
 		if (curViewBound.right > getLeft() + getWidth()) {
 			// Try to clip to the screen (right side)
-			curViewBound.right = getLeft() + getWidth();
-			curViewBound.left = curViewBound.right - curViewWidth;
+			clipViewOnTheRight(curViewBound, curViewWidth);
 		}
 		
 		// Left views starting from the current position
@@ -148,8 +152,7 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
 				// Si left side is outside the screen
 				if (bound.left < 0) {
 					// Try to clip to the screen (left side)
-					bound.left = 0;
-					bound.right = w;
+					 clipViewOnTheLeft(bound, w);
 					// Except if there's an intersection with the right view
 					if (iLoop < count - 1 && currentPosition != iLoop) {
 						Rect rightBound = bounds.get(iLoop + 1);
@@ -169,8 +172,7 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
 				// If right side is outside the screen
 				if (bound.right > getLeft() + getWidth()) {
 					// Try to clip to the screen (right side)
-					bound.right = getLeft() + getWidth();
-					bound.left = bound.right - w;
+					clipViewOnTheRight(bound, w);
 					// Except if there's an intersection with the left view
 					if (iLoop > 0 && currentPosition != iLoop) {
 						Rect leftBound = bounds.get(iLoop - 1);
@@ -214,6 +216,32 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
         path.close();
         canvas.drawPath(path, paintFooterTriangle);
 
+	}
+
+	/**
+	 * Set bounds for the right textView including clip padding.
+	 * 
+	 * @param curViewBound
+	 *            current bounds.
+	 * @param curViewWidth
+	 *            width of the view.
+	 */
+	private void clipViewOnTheRight(Rect curViewBound, int curViewWidth) {
+		curViewBound.right = getLeft() + getWidth() - clipPadding;
+		curViewBound.left = curViewBound.right - curViewWidth;
+	}
+
+	/**
+	 * Set bounds for the left textView including clip padding.
+	 * 
+	 * @param curViewBound
+	 *            current bounds.
+	 * @param curViewWidth
+	 *            width of the view.
+	 */
+	private void clipViewOnTheLeft(Rect curViewBound, int curViewWidth) {
+		curViewBound.left = 0 + clipPadding;
+		curViewBound.right = curViewWidth;
 	}
 
 	/**

--- a/viewflow/src/org/taptwo/android/widget/TitleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/TitleFlowIndicator.java
@@ -91,7 +91,7 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
 		int textColor = a.getColor(R.styleable.TitleFlowIndicator_textColor, TEXT_COLOR);
 		float textSize = a.getFloat(R.styleable.TitleFlowIndicator_textSize, TEXT_SIZE);
 		titlePadding = a.getInt(R.styleable.TitleFlowIndicator_titlePadding, TITLE_PADDING);
-		clipPadding = a.getColor(R.styleable.TitleFlowIndicator_clipPadding, CLIP_PADDING);
+		clipPadding = a.getInt(R.styleable.TitleFlowIndicator_clipPadding, CLIP_PADDING);
 		initDraw(textColor, textSize, selectedColor, selectedBold, footerLineHeight, footerColor);
 	}
 


### PR DESCRIPTION
As discussed before (issue #21) this pull request contains only TitleFlowIndicator.java, attrs.xml, and title_layout.xml.

Integer value that is defined by the property is used on the left side of the left view title and on the right side of the right view title so the views can have padding to the border to the parent view. Default value is 0.

'clipPadding' can be defined as attribute in xml layout see title_with_padding_layout.xml in viewflow_example project.
