### PR TITLE
Improved Circle Flow Indicator

### DIFF
--- a/viewflow-example/.classpath
+++ b/viewflow-example/.classpath
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
-	<classpathentry kind="src" path="viewflow_src"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="src" path="org_taptwo_android_widget_viewflow_src"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/viewflow"/>
+	<classpathentry kind="src" path="viewflow_src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/viewflow-example/.classpath
+++ b/viewflow-example/.classpath
@@ -5,5 +5,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="src" path="org_taptwo_android_widget_viewflow_src"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/viewflow"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/viewflow-example/.classpath
+++ b/viewflow-example/.classpath
@@ -4,7 +4,7 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="src" path="org_taptwo_android_widget_viewflow_src"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/viewflow"/>
 	<classpathentry kind="src" path="viewflow_src"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/viewflow"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/viewflow-example/res/layout/circle_layout.xml
+++ b/viewflow-example/res/layout/circle_layout.xml
@@ -9,8 +9,7 @@
 		android:layout_height="wrap_content"
 		android:layout_width="wrap_content"
 		android:id="@+id/viewflowindic"
-		android:layout_gravity="center_horizontal"
-		app:type="fill" />
+		android:layout_gravity="center_horizontal" />
 	<org.taptwo.android.widget.ViewFlow
 		android:id="@+id/viewflow" android:layout_width="fill_parent"
 		android:layout_height="fill_parent" app:sidebuffer="3"></org.taptwo.android.widget.ViewFlow>

--- a/viewflow-example/res/layout/circle_layout.xml
+++ b/viewflow-example/res/layout/circle_layout.xml
@@ -11,7 +11,7 @@
 		android:id="@+id/viewflowindic"
 		android:layout_gravity="center_horizontal"
 		app:inactiveType="fill"
-		app:fadeOut="1" />
+		app:fadeOut="1000" />
 	<org.taptwo.android.widget.ViewFlow
 		android:id="@+id/viewflow" android:layout_width="fill_parent"
 		android:layout_height="fill_parent" app:sidebuffer="3"></org.taptwo.android.widget.ViewFlow>

--- a/viewflow-example/res/layout/circle_layout.xml
+++ b/viewflow-example/res/layout/circle_layout.xml
@@ -10,7 +10,8 @@
 		android:layout_width="wrap_content"
 		android:id="@+id/viewflowindic"
 		android:layout_gravity="center_horizontal"
-		app:inactiveType="fill" />
+		app:inactiveType="fill"
+		app:fadeOut="1" />
 	<org.taptwo.android.widget.ViewFlow
 		android:id="@+id/viewflow" android:layout_width="fill_parent"
 		android:layout_height="fill_parent" app:sidebuffer="3"></org.taptwo.android.widget.ViewFlow>

--- a/viewflow-example/res/layout/circle_layout.xml
+++ b/viewflow-example/res/layout/circle_layout.xml
@@ -9,7 +9,8 @@
 		android:layout_height="wrap_content"
 		android:layout_width="wrap_content"
 		android:id="@+id/viewflowindic"
-		android:layout_gravity="center_horizontal" />
+		android:layout_gravity="center_horizontal"
+		app:inactiveType="fill" />
 	<org.taptwo.android.widget.ViewFlow
 		android:id="@+id/viewflow" android:layout_width="fill_parent"
 		android:layout_height="fill_parent" app:sidebuffer="3"></org.taptwo.android.widget.ViewFlow>

--- a/viewflow-example/res/layout/circle_layout.xml
+++ b/viewflow-example/res/layout/circle_layout.xml
@@ -1,26 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res/org.taptwo.android.widget.viewflow.example"
 	android:orientation="vertical" android:layout_width="fill_parent"
 	android:layout_height="fill_parent">
 
-
-
-	<LinearLayout android:layout_height="wrap_content"
-		android:layout_width="fill_parent" android:gravity="center_horizontal"
-		android:orientation="horizontal" android:id="@+id/header_layout">
-		<org.taptwo.android.widget.CircleFlowIndicator
-			android:padding="10dip" android:layout_height="wrap_content"
-			android:layout_width="wrap_content" android:id="@+id/viewflowindic"
-			android:background="#00000000"></org.taptwo.android.widget.CircleFlowIndicator>
-	</LinearLayout>
+	<org.taptwo.android.widget.CircleFlowIndicator
+		android:padding="10dip"
+		android:layout_height="wrap_content"
+		android:layout_width="wrap_content"
+		android:id="@+id/viewflowindic"
+		android:layout_gravity="center_horizontal"
+		app:type="fill" />
 	<org.taptwo.android.widget.ViewFlow
 		android:id="@+id/viewflow" android:layout_width="fill_parent"
 		android:layout_height="fill_parent" app:sidebuffer="3"></org.taptwo.android.widget.ViewFlow>
 
-
-
-
-
-
-</LinearLayout>
+</FrameLayout>

--- a/viewflow/res/values/attrs.xml
+++ b/viewflow/res/values/attrs.xml
@@ -23,7 +23,10 @@
         <attr name="strokeColor" format="color" />
         <attr name="radius" format="dimension" />
 		<attr name="centered" format="boolean" />
-		<attr name="type" format="string" />
+		<attr name="inactiveType">
+			<flag name="stroke" value="0" />
+			<flag name="fill" value="1" />
+		</attr>
     </declare-styleable>    
     <declare-styleable name="TitleFlowIndicator">
         <attr name="titlePadding" format="dimension" />

--- a/viewflow/res/values/attrs.xml
+++ b/viewflow/res/values/attrs.xml
@@ -19,11 +19,15 @@
         <attr name="sidebuffer" format="integer" />
     </declare-styleable>
     <declare-styleable name="CircleFlowIndicator">
-        <attr name="fillColor" format="color" />
-        <attr name="strokeColor" format="color" />
+        <attr name="activeColor" format="color" />
+        <attr name="inactiveColor" format="color" />
         <attr name="radius" format="dimension" />
 		<attr name="centered" format="boolean" />
 		<attr name="inactiveType">
+			<flag name="stroke" value="0" />
+			<flag name="fill" value="1" />
+		</attr>
+		<attr name="activeType">
 			<flag name="stroke" value="0" />
 			<flag name="fill" value="1" />
 		</attr>

--- a/viewflow/res/values/attrs.xml
+++ b/viewflow/res/values/attrs.xml
@@ -23,6 +23,7 @@
         <attr name="strokeColor" format="color" />
         <attr name="radius" format="dimension" />
 		<attr name="centered" format="boolean" />
+		<attr name="type" format="string" />
     </declare-styleable>    
     <declare-styleable name="TitleFlowIndicator">
         <attr name="titlePadding" format="dimension" />

--- a/viewflow/res/values/attrs.xml
+++ b/viewflow/res/values/attrs.xml
@@ -23,6 +23,7 @@
         <attr name="inactiveColor" format="color" />
         <attr name="radius" format="dimension" />
 		<attr name="centered" format="boolean" />
+		<attr name="fadeOut" format="integer" />
 		<attr name="inactiveType">
 			<flag name="stroke" value="0" />
 			<flag name="fill" value="1" />

--- a/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
@@ -41,11 +41,11 @@ import android.view.View;
  * </ul>
  */
 public class CircleFlowIndicator extends View implements FlowIndicator {
-	private static final int INACTIVE_STROKE = 0;
-	private static final int INACTIVE_FILL = 1;
+	private static final int STYLE_STROKE = 0;
+	private static final int STYLE_FILL = 1;
 	private float radius = 4;
 	private final Paint mPaintStroke = new Paint(Paint.ANTI_ALIAS_FLAG);
-	private final Paint mPaintFill = new Paint(Paint.ANTI_ALIAS_FLAG);
+	private final Paint mPaintActive = new Paint(Paint.ANTI_ALIAS_FLAG);
 	private ViewFlow viewFlow;
 	private int currentScroll = 0;
 	private int flowWidth = 0;
@@ -57,7 +57,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 	 */
 	public CircleFlowIndicator(Context context) {
 		super(context);
-		initColors(0xFFFFFFFF, 0xFFFFFFFF, INACTIVE_STROKE);
+		initColors(0xFFFFFFFF, 0xFFFFFFFF, STYLE_FILL, STYLE_STROKE);
 	}
 
 	/**
@@ -71,44 +71,66 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 		// Retrieve styles attributs
 		TypedArray a = context.obtainStyledAttributes(attrs,
 				R.styleable.CircleFlowIndicator);
-		// Retrieve the colors to be used for this view and apply them.
-		int activeColor = a.getColor(R.styleable.CircleFlowIndicator_fillColor,
-				0xFFFFFFFF);
+		
+		// Gets the inactive circle type, defaulting to "fill"
+		int activeType = a.getInt(
+				R.styleable.CircleFlowIndicator_activeType, STYLE_FILL);
+		// Work out the active color based on the type
+		int activeDefaultColor = 0xFFFFFFFF;
+		switch (activeType) {
+		case STYLE_STROKE:
+			activeDefaultColor = 0xFFFFC445;
+			break;
+		case STYLE_FILL:
+			activeDefaultColor = 0xFFFFFFFF;
+		}
+		// Get a custom inactive color if there is one
+		int activeColor = a.getColor(
+				R.styleable.CircleFlowIndicator_activeColor,
+				activeDefaultColor);
+		
 		// Gets the inactive circle type, defaulting to "stroke"
 		int inactiveType = a.getInt(
-				R.styleable.CircleFlowIndicator_inactiveType, INACTIVE_STROKE);
+				R.styleable.CircleFlowIndicator_inactiveType, STYLE_STROKE);
 		// Work out the inactive color based on the type
 		int inactiveDefaultColor = 0xFFFFFFFF;
 		switch (inactiveType) {
-		case INACTIVE_STROKE:
+		case STYLE_STROKE:
 			inactiveDefaultColor = 0xFFFFFFFF;
 			break;
-		case INACTIVE_FILL:
+		case STYLE_FILL:
 			inactiveDefaultColor = 0x44FFFFFF;
 		}
 		// Get a custom inactive color if there is one
 		int inactiveColor = a.getColor(
-				R.styleable.CircleFlowIndicator_strokeColor,
+				R.styleable.CircleFlowIndicator_inactiveColor,
 				inactiveDefaultColor);
 
 		// Retrieve the radius
 		radius = a.getDimension(R.styleable.CircleFlowIndicator_radius, 4.0f);
-		initColors(activeColor, inactiveColor, inactiveType);
+		initColors(activeColor, inactiveColor, activeType, inactiveType);
 	}
 
-	private void initColors(int activeColor, int inactiveColor, int inactiveType) {
+	private void initColors(int activeColor, int inactiveColor, int activeType, int inactiveType) {
 		// Select the paint type given the type attr
 		switch (inactiveType) {
-		case INACTIVE_STROKE:
+		case STYLE_STROKE:
 			mPaintStroke.setStyle(Style.STROKE);
 			break;
-		case INACTIVE_FILL:
+		case STYLE_FILL:
 			mPaintStroke.setStyle(Style.FILL);
 		}
 		mPaintStroke.setColor(inactiveColor);
 
-		mPaintFill.setStyle(Style.FILL);
-		mPaintFill.setColor(activeColor);
+		// Select the paint type given the type attr
+		switch (activeType) {
+		case STYLE_STROKE:
+			mPaintActive.setStyle(Style.STROKE);
+			break;
+		case STYLE_FILL:
+			mPaintActive.setStyle(Style.FILL);
+		}
+		mPaintActive.setColor(activeColor);
 	}
 
 	/*
@@ -136,7 +158,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 		}
 		// The flow width has been upadated yet. Draw the default position
 		canvas.drawCircle(getPaddingLeft() + radius + cx, getPaddingTop()
-				+ radius, radius, mPaintFill);
+				+ radius, radius, mPaintActive);
 
 	}
 
@@ -257,7 +279,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 	 *            ARGB value for the text
 	 */
 	public void setFillColor(int color) {
-		mPaintFill.setColor(color);
+		mPaintActive.setColor(color);
 		invalidate();
 	}
 

--- a/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
@@ -27,13 +27,22 @@ import android.view.View;
 
 /**
  * A FlowIndicator which draws circles (one for each view). The current view
- * position is filled and others are only striked.<br/><br/>
+ * position is filled and others are only striked.<br/>
+ * <br/>
  * Availables attributes are:<br/>
- * <ul>fillColor: Define the color used to fill a circle (default to white)</ul>
- * <ul>strokeColor: Define the color used to stroke a circle (default to white)</ul>
- * <ul>radius: Define the circle radius (default to 4.0)</ul>
+ * <ul>
+ * fillColor: Define the color used to fill a circle (default to white)
+ * </ul>
+ * <ul>
+ * strokeColor: Define the color used to stroke a circle (default to white)
+ * </ul>
+ * <ul>
+ * radius: Define the circle radius (default to 4.0)
+ * </ul>
  */
 public class CircleFlowIndicator extends View implements FlowIndicator {
+	private static final int INACTIVE_STROKE = 0;
+	private static final int INACTIVE_FILL = 1;
 	private float radius = 4;
 	private final Paint mPaintStroke = new Paint(Paint.ANTI_ALIAS_FLAG);
 	private final Paint mPaintFill = new Paint(Paint.ANTI_ALIAS_FLAG);
@@ -48,7 +57,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 	 */
 	public CircleFlowIndicator(Context context) {
 		super(context);
-		initColors(0xFFFFFFFF, 0xFFFFFFFF, "stroke");
+		initColors(0xFFFFFFFF, 0xFFFFFFFF, INACTIVE_STROKE);
 	}
 
 	/**
@@ -65,32 +74,39 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 		// Retrieve the colors to be used for this view and apply them.
 		int activeColor = a.getColor(R.styleable.CircleFlowIndicator_fillColor,
 				0xFFFFFFFF);
-		String type = a.getString(R.styleable.CircleFlowIndicator_type);
-		int inactiveColor;
-		if (type != null && type.equals("fill")) {
-			inactiveColor = a.getColor(
-				R.styleable.CircleFlowIndicator_strokeColor, 0x44FFFFFF);
+		// Gets the inactive circle type, defaulting to "stroke"
+		int inactiveType = a.getInt(
+				R.styleable.CircleFlowIndicator_inactiveType, INACTIVE_STROKE);
+		// Work out the inactive color based on the type
+		int inactiveDefaultColor = 0xFFFFFFFF;
+		switch (inactiveType) {
+		case INACTIVE_STROKE:
+			inactiveDefaultColor = 0xFFFFFFFF;
+			break;
+		case INACTIVE_FILL:
+			inactiveDefaultColor = 0x44FFFFFF;
 		}
-		else {
-			inactiveColor = a.getColor(
-					R.styleable.CircleFlowIndicator_strokeColor, 0xFFFFFFFF);
-		}
+		// Get a custom inactive color if there is one
+		int inactiveColor = a.getColor(
+				R.styleable.CircleFlowIndicator_strokeColor,
+				inactiveDefaultColor);
+
 		// Retrieve the radius
 		radius = a.getDimension(R.styleable.CircleFlowIndicator_radius, 4.0f);
-		initColors(activeColor, inactiveColor, type);
+		initColors(activeColor, inactiveColor, inactiveType);
 	}
 
-	private void initColors(int activeColor, int inactiveColor, String type) {
-		if (type != null && type.equals("fill")) {
+	private void initColors(int activeColor, int inactiveColor, int inactiveType) {
+		// Select the paint type given the type attr
+		switch (inactiveType) {
+		case INACTIVE_STROKE:
+			mPaintStroke.setStyle(Style.STROKE);
+			break;
+		case INACTIVE_FILL:
 			mPaintStroke.setStyle(Style.FILL);
 		}
-		else {
-			mPaintStroke.setStyle(Style.STROKE);
-		}
 		mPaintStroke.setColor(inactiveColor);
-		mPaintStroke.setAntiAlias(true);
-		mPaintStroke.setDither(true);
-		
+
 		mPaintFill.setStyle(Style.FILL);
 		mPaintFill.setColor(activeColor);
 	}
@@ -119,9 +135,9 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 			cx = (currentScroll * (2 * radius + radius)) / flowWidth;
 		}
 		// The flow width has been upadated yet. Draw the default position
-	    canvas.drawCircle(getPaddingLeft() + radius + cx,
-					getPaddingTop() + radius, radius, mPaintFill);
-		
+		canvas.drawCircle(getPaddingLeft() + radius + cx, getPaddingTop()
+				+ radius, radius, mPaintFill);
+
 	}
 
 	/*
@@ -135,8 +151,12 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 	public void onSwitched(View view, int position) {
 	}
 
-	/* (non-Javadoc)
-	 * @see org.taptwo.android.widget.FlowIndicator#setViewFlow(org.taptwo.android.widget.ViewFlow)
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.taptwo.android.widget.FlowIndicator#setViewFlow(org.taptwo.android
+	 * .widget.ViewFlow)
 	 */
 	@Override
 	public void setViewFlow(ViewFlow view) {
@@ -145,10 +165,11 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 		invalidate();
 	}
 
-	
-	
-	/* (non-Javadoc)
-	 * @see org.taptwo.android.widget.FlowIndicator#onScrolled(int, int, int, int)
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.taptwo.android.widget.FlowIndicator#onScrolled(int, int, int,
+	 * int)
 	 */
 	@Override
 	public void onScrolled(int h, int v, int oldh, int oldv) {
@@ -190,7 +211,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 			if (viewFlow != null) {
 				count = viewFlow.getViewsCount();
 			}
-			result = (int)(getPaddingLeft() + getPaddingRight()
+			result = (int) (getPaddingLeft() + getPaddingRight()
 					+ (count * 2 * radius) + (count - 1) * radius + 1);
 			// Respect AT_MOST value if that was what is called for by
 			// measureSpec
@@ -219,7 +240,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 		}
 		// Measure the height
 		else {
-			result = (int)(2 * radius + getPaddingTop() + getPaddingBottom() + 1);
+			result = (int) (2 * radius + getPaddingTop() + getPaddingBottom() + 1);
 			// Respect AT_MOST value if that was what is called for by
 			// measureSpec
 			if (specMode == MeasureSpec.AT_MOST) {

--- a/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
@@ -23,6 +23,7 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Paint.Style;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.View;
 
 /**
@@ -43,12 +44,14 @@ import android.view.View;
 public class CircleFlowIndicator extends View implements FlowIndicator {
 	private static final int STYLE_STROKE = 0;
 	private static final int STYLE_FILL = 1;
+	
 	private float radius = 4;
 	private final Paint mPaintStroke = new Paint(Paint.ANTI_ALIAS_FLAG);
 	private final Paint mPaintActive = new Paint(Paint.ANTI_ALIAS_FLAG);
 	private ViewFlow viewFlow;
 	private int currentScroll = 0;
 	private int flowWidth = 0;
+	private FadeTimer timer;
 
 	/**
 	 * Default constructor
@@ -109,6 +112,8 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 		// Retrieve the radius
 		radius = a.getDimension(R.styleable.CircleFlowIndicator_radius, 4.0f);
 		initColors(activeColor, inactiveColor, activeType, inactiveType);
+		
+		
 	}
 
 	private void initColors(int activeColor, int inactiveColor, int activeType,
@@ -182,6 +187,9 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 	 */
 	@Override
 	public void setViewFlow(ViewFlow view) {
+		timer = new FadeTimer();
+		timer.start();
+		
 		viewFlow = view;
 		flowWidth = viewFlow.getWidth();
 		invalidate();
@@ -195,6 +203,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 	 */
 	@Override
 	public void onScrolled(int h, int v, int oldh, int oldv) {
+		timer.resetTimer();
 		currentScroll = h;
 		flowWidth = viewFlow.getWidth();
 		invalidate();
@@ -292,5 +301,32 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 	public void setStrokeColor(int color) {
 		mPaintStroke.setColor(color);
 		invalidate();
+	}
+	
+	// TODO: Stop this counting when view not in view
+	// TODO: Stop counting when limit hit
+	// TODO: Start animation when limit hit
+	private class FadeTimer extends Thread {
+		private int timer = 0;
+		private boolean _run = true;
+		
+		public void resetTimer() {
+			Log.d("Circle", "Timer reset");
+			timer = 0;
+		}
+		
+		@Override
+		public void run() {
+			while (_run) {
+				try {
+					Thread.sleep(1000);
+					timer++;
+					Log.d("Circle", "Timer\t" + timer);
+				} catch (InterruptedException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+			}
+		}
 	}
 }

--- a/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
@@ -71,35 +71,35 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 		// Retrieve styles attributs
 		TypedArray a = context.obtainStyledAttributes(attrs,
 				R.styleable.CircleFlowIndicator);
-		
+
 		// Gets the inactive circle type, defaulting to "fill"
-		int activeType = a.getInt(
-				R.styleable.CircleFlowIndicator_activeType, STYLE_FILL);
+		int activeType = a.getInt(R.styleable.CircleFlowIndicator_activeType,
+				STYLE_FILL);
 		// Work out the active color based on the type
-		int activeDefaultColor = 0xFFFFFFFF;
+		int activeDefaultColor;
 		switch (activeType) {
 		case STYLE_STROKE:
 			activeDefaultColor = 0xFFFFC445;
 			break;
-		case STYLE_FILL:
+		default:
 			activeDefaultColor = 0xFFFFFFFF;
 		}
 		// Get a custom inactive color if there is one
-		int activeColor = a.getColor(
-				R.styleable.CircleFlowIndicator_activeColor,
-				activeDefaultColor);
-		
+		int activeColor = a
+				.getColor(R.styleable.CircleFlowIndicator_activeColor,
+						activeDefaultColor);
+
 		// Gets the inactive circle type, defaulting to "stroke"
 		int inactiveType = a.getInt(
 				R.styleable.CircleFlowIndicator_inactiveType, STYLE_STROKE);
 		// Work out the inactive color based on the type
-		int inactiveDefaultColor = 0xFFFFFFFF;
+		int inactiveDefaultColor;
 		switch (inactiveType) {
-		case STYLE_STROKE:
-			inactiveDefaultColor = 0xFFFFFFFF;
-			break;
 		case STYLE_FILL:
 			inactiveDefaultColor = 0x44FFFFFF;
+			break;
+		default:
+			inactiveDefaultColor = 0xFFFFFFFF;
 		}
 		// Get a custom inactive color if there is one
 		int inactiveColor = a.getColor(
@@ -111,14 +111,15 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 		initColors(activeColor, inactiveColor, activeType, inactiveType);
 	}
 
-	private void initColors(int activeColor, int inactiveColor, int activeType, int inactiveType) {
+	private void initColors(int activeColor, int inactiveColor, int activeType,
+			int inactiveType) {
 		// Select the paint type given the type attr
 		switch (inactiveType) {
-		case STYLE_STROKE:
-			mPaintStroke.setStyle(Style.STROKE);
-			break;
 		case STYLE_FILL:
 			mPaintStroke.setStyle(Style.FILL);
+			break;
+		default:
+			mPaintStroke.setStyle(Style.STROKE);
 		}
 		mPaintStroke.setColor(inactiveColor);
 
@@ -127,7 +128,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 		case STYLE_STROKE:
 			mPaintActive.setStyle(Style.STROKE);
 			break;
-		case STYLE_FILL:
+		default:
 			mPaintActive.setStyle(Style.FILL);
 		}
 		mPaintActive.setColor(activeColor);
@@ -159,7 +160,6 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 		// The flow width has been upadated yet. Draw the default position
 		canvas.drawCircle(getPaddingLeft() + radius + cx, getPaddingTop()
 				+ radius, radius, mPaintActive);
-
 	}
 
 	/*

--- a/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Patrik Åkerfeldt
+ * Copyright (C) 2011 Patrik ÔøΩkerfeldt
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 	 */
 	public CircleFlowIndicator(Context context) {
 		super(context);
-		initColors(0xFFFFFFFF, 0xFFFFFFFF);
+		initColors(0xFFFFFFFF, 0xFFFFFFFF, "stroke");
 	}
 
 	/**
@@ -63,20 +63,36 @@ public class CircleFlowIndicator extends View implements FlowIndicator {
 		TypedArray a = context.obtainStyledAttributes(attrs,
 				R.styleable.CircleFlowIndicator);
 		// Retrieve the colors to be used for this view and apply them.
-		int fillColor = a.getColor(R.styleable.CircleFlowIndicator_fillColor,
+		int activeColor = a.getColor(R.styleable.CircleFlowIndicator_fillColor,
 				0xFFFFFFFF);
-		int strokeColor = a.getColor(
-				R.styleable.CircleFlowIndicator_strokeColor, 0xFFFFFFFF);
+		String type = a.getString(R.styleable.CircleFlowIndicator_type);
+		int inactiveColor;
+		if (type != null && type.equals("fill")) {
+			inactiveColor = a.getColor(
+				R.styleable.CircleFlowIndicator_strokeColor, 0x44FFFFFF);
+		}
+		else {
+			inactiveColor = a.getColor(
+					R.styleable.CircleFlowIndicator_strokeColor, 0xFFFFFFFF);
+		}
 		// Retrieve the radius
 		radius = a.getDimension(R.styleable.CircleFlowIndicator_radius, 4.0f);
-		initColors(fillColor, strokeColor);
+		initColors(activeColor, inactiveColor, type);
 	}
 
-	private void initColors(int fillColor, int strokeColor) {
-		mPaintStroke.setStyle(Style.STROKE);
-		mPaintStroke.setColor(strokeColor);
+	private void initColors(int activeColor, int inactiveColor, String type) {
+		if (type != null && type.equals("fill")) {
+			mPaintStroke.setStyle(Style.FILL);
+		}
+		else {
+			mPaintStroke.setStyle(Style.STROKE);
+		}
+		mPaintStroke.setColor(inactiveColor);
+		mPaintStroke.setAntiAlias(true);
+		mPaintStroke.setDither(true);
+		
 		mPaintFill.setStyle(Style.FILL);
-		mPaintFill.setColor(fillColor);
+		mPaintFill.setColor(activeColor);
 	}
 
 	/*

--- a/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
@@ -315,7 +315,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 	 * Resets the fade out timer to 0. Creating a new one if needed
 	 */
 	private void resetTimer() {
-		// Only set the timer if we have a timeout of at least 1 second
+		// Only set the timer if we have a timeout of at least 1 millisecond
 		if (fadeOutTime > 0) {
 			// Check if we need to create a new timer
 			if (timer == null || timer._run == false) {
@@ -347,8 +347,8 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 		protected Void doInBackground(Void... arg0) {
 			while (_run) {
 				try {
-					// Wait for a second
-					Thread.sleep(1000);
+					// Wait for a millisecond
+					Thread.sleep(1);
 					// Increment the timer
 					timer++;
 


### PR DESCRIPTION
Added a few new features to the circle indicator:
- Change between fill and stroke for active and inactive circles to achieve more effects
- Added ability to fade out indicator after a certain timeout since the viewflow was moved

Between these changes you can create a more visually appealing indicator.

One thing to note is that I've renamed the _fillColor_ and _strokeColor_ attributes to _inactiveColor_ and _activeColor_ to more accurately show their new purpose. This means that when upgrading some people may not see the exact results they had before.

If you have any comments that would be appreciated! :-)

Matt
