### PR TITLE
dynamically resizeable adapter

### DIFF
--- a/viewflow/src/org/taptwo/android/widget/TitleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/TitleFlowIndicator.java
@@ -149,7 +149,12 @@ public class TitleFlowIndicator extends TextView implements FlowIndicator {
 
 		// Calculate views bounds
 		ArrayList<Rect> bounds = calculateAllBounds(paintText);
-
+		
+		// Extra check required for resizeable adapters
+		if (currentPosition > bounds.size()) {
+			return;
+		}
+		
 		// If no value then add a fake one
 		int count = (viewFlow != null && viewFlow.getAdapter() != null) ? viewFlow.getAdapter().getCount() : 1;
 

--- a/viewflow/src/org/taptwo/android/widget/ViewFlow.java
+++ b/viewflow/src/org/taptwo/android/widget/ViewFlow.java
@@ -593,9 +593,16 @@ public class ViewFlow extends AdapterView<Adapter> {
 
 			// Add new view to buffer
 			int newBufferIndex = mCurrentAdapterIndex + mSideBuffer;
-			if (newBufferIndex < mAdapter.getCount())
-				mLoadedViews.addLast(makeAndAddView(newBufferIndex, true,
+			if (newBufferIndex < mAdapter.getCount()) {
+				
+				//extra out of bounds check after making the view
+				try {
+					mLoadedViews.addLast(makeAndAddView(newBufferIndex, true,
 						recycleView));
+				} catch (ViewOutOfBoundsException e) {
+					Log.d("viewflow", "not adding view at position "+newBufferIndex+", it is out of bounds");
+				}
+			}
 
 		} else { // to the left
 			mCurrentAdapterIndex--;
@@ -649,6 +656,12 @@ public class ViewFlow extends AdapterView<Adapter> {
 
 	private View makeAndAddView(int position, boolean addToEnd, View convertView) {
 		View view = mAdapter.getView(position, convertView, this);
+		
+		//Check the count again before adding the child.
+		//This allows the adapter to be resized dynamically in the getView method if you have a non-constant data set.
+		if (position >= mAdapter.getCount()) {
+			throw new ViewOutOfBoundsException();
+		}
 		return setupChild(view, addToEnd, convertView != null);
 	}
 

--- a/viewflow/src/org/taptwo/android/widget/ViewOutOfBoundsException.java
+++ b/viewflow/src/org/taptwo/android/widget/ViewOutOfBoundsException.java
@@ -1,0 +1,14 @@
+package org.taptwo.android.widget;
+
+/**
+ * Handles the situation where a View has been requested but it is outside the adapter range.
+ * This can occur in situations where the adapter range is adjusted dynamically after the ViewFlow widget is created.
+ * 
+ * @author polly
+ *
+ */
+public class ViewOutOfBoundsException extends RuntimeException {
+
+	private static final long serialVersionUID = 8160977913873774611L;
+
+}


### PR DESCRIPTION
added ability to resize the viewflow adapter after initial creation, for dynamic data sets. Now it is possible to change the viewflow adapter getCount value during its getView method, and the widget will respond to the newly imposed boundary.

I needed this for an app which didn't know how many pages the viewflow widget needed to have until the adapter getView method returned an empty data set. Thought it might be useful to other people.

thanks for an awesome widget btw, i love it! :)
