### PR TITLE
CircleFlowIndicator - adding 'spacing' attribute

### DIFF
--- a/viewflow/res/values/attrs.xml
+++ b/viewflow/res/values/attrs.xml
@@ -22,6 +22,7 @@
         <attr name="activeColor" format="color" />
         <attr name="inactiveColor" format="color" />
         <attr name="radius" format="dimension" />
+        <attr name="spacing" format="dimension" />
 		<attr name="centered" format="boolean" />
 		<attr name="fadeOut" format="integer" />
 		<attr name="inactiveType">

--- a/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
@@ -51,6 +51,9 @@ import android.view.animation.Animation.AnimationListener;
  * <ul>
  * radius: Define the circle radius (default to 4.0)
  * </ul>
+ *  * <ul>
+ * spacing: Define the circle spacing (default to 4.0)
+ * </ul>
  */
 public class CircleFlowIndicator extends View implements FlowIndicator,
 		AnimationListener {
@@ -58,6 +61,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 	private static final int STYLE_FILL = 1;
 
 	private float radius = 4;
+	private float spacing = 4;
 	private int fadeOutTime = 0;
 	private final Paint mPaintInactive = new Paint(Paint.ANTI_ALIAS_FLAG);
 	private final Paint mPaintActive = new Paint(Paint.ANTI_ALIAS_FLAG);
@@ -91,13 +95,13 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 		TypedArray a = context.obtainStyledAttributes(attrs,
 				R.styleable.CircleFlowIndicator);
 
-		// Gets the inactive circle type, defaulting to "fill"
+		// Gets the active circle type, defaulting to "fill"
 		int activeType = a.getInt(R.styleable.CircleFlowIndicator_activeType,
 				STYLE_FILL);
 		
 		int activeDefaultColor = 0xFFFFFFFF;
 		
-		// Get a custom inactive color if there is one
+		// Get a custom active color if there is one
 		int activeColor = a
 				.getColor(R.styleable.CircleFlowIndicator_activeColor,
 						activeDefaultColor);
@@ -114,6 +118,9 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 
 		// Retrieve the radius
 		radius = a.getDimension(R.styleable.CircleFlowIndicator_radius, 4.0f);
+		
+		// Retrieve the spacing
+		spacing = a.getDimension(R.styleable.CircleFlowIndicator_spacing, 4.0f);
 		
 		// Retrieve the fade out time
 		fadeOutTime = a.getInt(R.styleable.CircleFlowIndicator_fadeOut, 0);
@@ -159,7 +166,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 			count = viewFlow.getViewsCount();
 		}
 		
-		float circleSeparation = 2*radius+radius;
+		float circleSeparation = 2*radius+spacing;
 		//this is the amount the first circle should be offset to make the entire thing centered
 		float centeringOffset = 0;
 		
@@ -174,7 +181,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 		float cx = 0;
 		if (flowWidth != 0) {
 			// Draw the filled circle according to the current scroll
-			cx = (currentScroll * (2 * radius + radius)) / flowWidth;
+			cx = (currentScroll * (2 * radius + spacing)) / flowWidth;
 		}
 		// The flow width has been upadated yet. Draw the default position
 		canvas.drawCircle(leftPadding + radius + cx+centeringOffset, getPaddingTop()
@@ -256,7 +263,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 				count = viewFlow.getViewsCount();
 			}
 			result = (int) (getPaddingLeft() + getPaddingRight()
-					+ (count * 2 * radius) + (count - 1) * radius + 1);
+					+ (count * 2 * radius) + (count - 1) * spacing + 1);
 			// Respect AT_MOST value if that was what is called for by
 			// measureSpec
 			if (specMode == MeasureSpec.AT_MOST) {


### PR DESCRIPTION
CircleFlowIndicator - Allows circle spacing that is different to radius.

Added a 'spacing' field and attribute which replaces the 'radius' field in some of the calculations to make the spacing no longer proportional to the radius.
