### PR TITLE
Fix non-UTF-8 characters in comments

### DIFF
--- a/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Patrik �kerfeldt
+ * Copyright (C) 2011 Patrik Åkerfeldt
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/viewflow/src/org/taptwo/android/widget/FlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/FlowIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Patrik Åkerfeldt
+ * Copyright (C) 2011 Patrik √Ökerfeldt
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/viewflow/src/org/taptwo/android/widget/TitleProvider.java
+++ b/viewflow/src/org/taptwo/android/widget/TitleProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Patrik Åkerfeldt
+ * Copyright (C) 2011 Patrik √Ökerfeldt
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The non-UTF-8 characters cause build errors in newer Java compilers. I notice they've already been fixed in two files.
