### PR TITLE
Implement measure and layout so that non-fixed sizes can be used

### DIFF
--- a/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
@@ -226,7 +226,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 	public void setViewFlow(ViewFlow view) {
 		resetTimer();
 		viewFlow = view;
-		flowWidth = viewFlow.getWidth();
+		flowWidth = viewFlow.getChildWidth();
 		invalidate();
 	}
 
@@ -241,7 +241,7 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 		setVisibility(View.VISIBLE);
 		resetTimer();
 		currentScroll = h;
-		flowWidth = viewFlow.getWidth();
+		flowWidth = viewFlow.getChildWidth();
 		invalidate();
 	}
 

--- a/viewflow/src/org/taptwo/android/widget/ViewFlow.java
+++ b/viewflow/src/org/taptwo/android/widget/ViewFlow.java
@@ -296,7 +296,8 @@ public class ViewFlow extends AdapterView<Adapter> {
 				} else if (deltaX > 0) {
 					final int availableToScroll = getChildAt(
 							getChildCount() - 1).getRight()
-							- scrollX - getChildWidth();
+							- getPaddingRight() - getHorizontalFadingEdgeLength()
+							- scrollX - getWidth();
 					if (availableToScroll > 0) {
 						scrollBy(Math.min(availableToScroll, deltaX), 0);
 					}
@@ -394,6 +395,7 @@ public class ViewFlow extends AdapterView<Adapter> {
 				} else if (deltaX > 0) {
 					final int availableToScroll = getChildAt(
 							getChildCount() - 1).getRight()
+							- getPaddingRight() - getHorizontalFadingEdgeLength()
 							- scrollX - getChildWidth();
 					if (availableToScroll > 0) {
 						scrollBy(Math.min(availableToScroll, deltaX), 0);

--- a/viewflow/src/org/taptwo/android/widget/ViewFlow.java
+++ b/viewflow/src/org/taptwo/android/widget/ViewFlow.java
@@ -198,7 +198,7 @@ public class ViewFlow extends AdapterView<Adapter> {
 		return getPaddingLeft() + getPaddingRight() + getHorizontalFadingEdgeLength() * 2;
 	}
 
-	private int getChildWidth() {
+	public int getChildWidth() {
 		return getWidth() - getWidthPadding();
 	}
 
@@ -206,7 +206,7 @@ public class ViewFlow extends AdapterView<Adapter> {
 		return getPaddingTop() + getPaddingBottom();
 	}
 
-	private int getChildHeight() {
+	public int getChildHeight() {
 		return getHeight() - getHeightPadding();
 	}
 

--- a/viewflow/src/org/taptwo/android/widget/ViewFlow.java
+++ b/viewflow/src/org/taptwo/android/widget/ViewFlow.java
@@ -254,6 +254,24 @@ public class ViewFlow extends AdapterView<Adapter> {
 		}
 	}
 
+	@Override protected float getTopFadingEdgeStrength() {
+		return 0.0f;
+	}
+
+	@Override protected float getBottomFadingEdgeStrength() {
+		return 0.0f;
+	}
+
+	@Override protected float getLeftFadingEdgeStrength() {
+		// always do the fading edge
+		return 1.0f;
+	}
+
+	@Override protected float getRightFadingEdgeStrength() {
+		// always do the fading edge
+		return 1.0f;
+	}
+
 	@Override
 	public boolean onInterceptTouchEvent(MotionEvent ev) {
 		if (getChildCount() == 0)

--- a/viewflow/src/org/taptwo/android/widget/ViewFlow.java
+++ b/viewflow/src/org/taptwo/android/widget/ViewFlow.java
@@ -499,7 +499,11 @@ public class ViewFlow extends AdapterView<Adapter> {
 			mCurrentScreen = Math.max(0,
 					Math.min(mNextScreen, getChildCount() - 1));
 			mNextScreen = INVALID_SCREEN;
-			postViewSwitched(mLastScrollDirection);
+			post(new Runnable() {
+				@Override public void run() {
+					postViewSwitched(mLastScrollDirection);
+				}
+			});
 		}
 	}
 


### PR DESCRIPTION
This series of changes allows non-fixed sizes to be used, by measuring the first child in onMeasure in a similar way to ListView. This makes ViewFlow a lot more useful. In addition, it adds fading edge support. This optionally adds extra padding to either side of the child view, so the neighbouring child views can be partially displayed, fading out towards the edge. Although fading edge is out of fashion in Android these days, for this kind of view it can make the swipe-to-next-page affordance a lot clearer to users.

Also, the branch fixes what's arguably a bug in CircleFlowIndicator, where stroked circles are larger than filled circles. A stroked circle's radius is to the centre of the stroke, not the outside, so if you use the same radius for both, the stroked circle is larger. This change avoids that problem by adjusting the size if stroke is used. The visible effect of this is that if you use the common technique of having inactive pages stroked and the active page filled in a different colour, the stroke is no longer visible around the outside of the active page's circle.
