### PR TITLE
Circleflow snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,15 @@ And then you'll need to connect your `ViewFlow` with the `FlowIndicator`:
 
 	CircleFlowIndicator indic = (CircleFlowIndicator) findViewById(R.id.viewflowindic);
 	viewFlow.setFlowIndicator(indic);
-	
-The following attributes are supported: `activeColor`, `inactiveColor`, `activeType` (either fill or stroke), `inactiveType` (either fill or stroke), `fadeOut` (time in ms until indicator fades out, 0 = never), `radius`.
+
+By default, the 'active' indicator moves smoothly from one 'inactive' indicator
+to the next, as the user scrolls. If you set the `snap` attribute to `true`, it
+will instead jump to the next position when the flow settles at the next page.
+
+The following attributes are supported: `activeColor`, `inactiveColor`,
+`activeType` (either fill or stroke), `inactiveType` (either fill or stroke),
+`fadeOut` (time in ms until indicator fades out, 0 = never), `radius`, `sync`
+(see above).
 
 #### Title Flow Indicator ####
 This indicator presents the title of the previous, current and next `View` in the adapter (see screenshot below).

--- a/viewflow/res/values/attrs.xml
+++ b/viewflow/res/values/attrs.xml
@@ -33,6 +33,7 @@
 			<flag name="stroke" value="0" />
 			<flag name="fill" value="1" />
 		</attr>
+		<attr name="snap" format="boolean" />
     </declare-styleable>    
     <declare-styleable name="TitleFlowIndicator">
         <attr name="titlePadding" format="dimension" />

--- a/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
@@ -31,27 +31,29 @@ import org.taptwo.android.widget.viewflow.R;
 /**
  * A FlowIndicator which draws circles (one for each view). 
  * <br/>
- * Availables attributes are:<br/>
+ * Available attributes are:<br/>
  * <ul>
+ * <li>
  * activeColor: Define the color used to draw the active circle (default to white)
- * </ul>
- * <ul>
+ * </li>
+ * <li>
  * inactiveColor: Define the color used to draw the inactive circles (default to 0x44FFFFFF)
- * </ul>
- * <ul>
+ * </li>
+ * <li>
  * inactiveType: Define how to draw the inactive circles, either stroke or fill (default to stroke)
- * </ul>
- * <ul>
+ * </li>
+ * <li>
  * activeType: Define how to draw the active circle, either stroke or fill (default to fill)
- * </ul>
- * <ul>
+ * </li>
+ * <li>
  * fadeOut: Define the time (in ms) until the indicator will fade out (default to 0 = never fade out)
- * </ul>
- * <ul>
+ * </li>
+ * <li>
  * radius: Define the circle outer radius (default to 4.0)
- * </ul>
- *	* <ul>
+ * </li>
+ * <li>
  * spacing: Define the circle spacing (default to 4.0)
+ * </li>
  * </ul>
  */
 public class CircleFlowIndicator extends View implements FlowIndicator,

--- a/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
+++ b/viewflow/src/org/taptwo/android/widget/CircleFlowIndicator.java
@@ -54,6 +54,9 @@ import org.taptwo.android.widget.viewflow.R;
  * <li>
  * spacing: Define the circle spacing (default to 4.0)
  * </li>
+ * <li>
+ * snap: If true, the 'active' indicator snaps from one page to the next; otherwise, it moves smoothly.
+ * </li>
  * </ul>
  */
 public class CircleFlowIndicator extends View implements FlowIndicator,
@@ -70,11 +73,13 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 	private final Paint mPaintActive = new Paint(Paint.ANTI_ALIAS_FLAG);
 	private ViewFlow viewFlow;
 	private int currentScroll = 0;
+	private int currentPosition = 0;
 	private int flowWidth = 0;
 	private FadeTimer timer;
 	public AnimationListener animationListener = this;
 	private Animation animation;
 	private boolean mCentered = false;
+	private boolean mSnap = false;
 
 	/**
 	 * Default constructor
@@ -133,6 +138,8 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 		fadeOutTime = a.getInt(R.styleable.CircleFlowIndicator_fadeOut, 0);
 		
 		mCentered = a.getBoolean(R.styleable.CircleFlowIndicator_centered, false);
+
+		mSnap = a.getBoolean(R.styleable.CircleFlowIndicator_snap, false);
 		
 		initColors(activeColor, inactiveColor, activeType, inactiveType);
 	}
@@ -197,11 +204,15 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 					getPaddingTop() + mRadius, mRadiusInactive, mPaintInactive);
 		}
 		float cx = 0;
-		if (flowWidth != 0) {
-			// Draw the filled circle according to the current scroll
-			cx = (currentScroll * spacing) / flowWidth;
+		if (mSnap) {
+			cx = currentPosition * spacing;
+		} else {
+			if (flowWidth != 0) {
+				// Draw the filled circle according to the current scroll
+				cx = (currentScroll * spacing) / flowWidth;
+			}
+			// else, the flow width hasn't been updated yet. Draw the default position.
 		}
-		// The flow width has been upadated yet. Draw the default position
 		canvas.drawCircle(leftPadding + mRadius + cx+centeringOffset, getPaddingTop()
 				+ mRadius, mRadiusActive, mPaintActive);
 	}
@@ -215,6 +226,12 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 	 */
 	@Override
 	public void onSwitched(View view, int position) {
+		currentPosition = position;
+		if (mSnap) {
+			setVisibility(View.VISIBLE);
+			resetTimer();
+			invalidate();
+		}
 	}
 
 	/*
@@ -240,11 +257,13 @@ public class CircleFlowIndicator extends View implements FlowIndicator,
 	 */
 	@Override
 	public void onScrolled(int h, int v, int oldh, int oldv) {
-		setVisibility(View.VISIBLE);
-		resetTimer();
 		currentScroll = h;
 		flowWidth = viewFlow.getChildWidth();
-		invalidate();
+		if (!mSnap) {
+			setVisibility(View.VISIBLE);
+			resetTimer();
+			invalidate();
+		}
 	}
 
 	/*


### PR DESCRIPTION
The existing behaviour moves the 'active' indicator smoothly between pages. I think it looks a little neater in some cases if the circle just appears at the new page instead, so I've added that behaviour as an option. The "snap" name comes from Jake Wharton's ViewPagerIndicator, IIRC, but the code is unrelated. With 'snap' turned on, it looks like the inactive indicator changes to the active indicator instead of the active indicator moving along.

I've also updated the README with a description of the new option.
