### PR TITLE
adapter getview position always return 0

### DIFF
--- a/viewflow/src/org/taptwo/android/widget/ViewFlow.java
+++ b/viewflow/src/org/taptwo/android/widget/ViewFlow.java
@@ -164,7 +164,8 @@ public class ViewFlow extends AdapterView<Adapter> {
 
 		int count = mAdapter == null ? 0 : mAdapter.getCount();
 		if (count > 0) {
-			final View child = obtainView(0);
+			//final View child = obtainView(0);
+			final View child = obtainView(mCurrentAdapterIndex);
 			measureChild(child, widthMeasureSpec, heightMeasureSpec);
 			childWidth = child.getMeasuredWidth();
 			childHeight = child.getMeasuredHeight();


### PR DESCRIPTION
when the adapter getView convertView parameter has been created,the position parameter always return 0.
because in onMeasure function viewflow call obtainView pass 0(line 167),it need to pass mCurrentAdapterIndex.
